### PR TITLE
Increase nginx read timeout

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -41,6 +41,9 @@ spec:
               value: 'FALSE'
             - name: PROXY_REDIRECT
               value: 'https://127.0.0.1:5000 https://$host; proxy_redirect https://{{.URL}}:10443 https://$host'
+            - name: ADD_NGINX_SERVER_CFG
+              value: |
+                proxy_read_timeout  300s;
           ports:
             - name: https
               containerPort: 10443

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               value: 'https://127.0.0.1:5000 https://$host; proxy_redirect https://{{.URL}}:10443 https://$host'
             - name: ADD_NGINX_SERVER_CFG
               value: |
-                proxy_read_timeout  300s;
+                proxy_read_timeout 300s;
           ports:
             - name: https
               containerPort: 10443


### PR DESCRIPTION
This fix increases the timeout limit on the Nginx proxy to 5 minutes, so that it doesn't drop connections while waiting for a response from Tableau.