### PR TITLE
Enable url cutover for AWS Go Live

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ pipeline:
     environment:
       - KUBE_NAMESPACE=dq-apps
       - INSECURE_SKIP_TLS_VERIFY=true
-      - URL=analysis.prod.dq.homeoffice.gov.uk
+      - URL=analysis.dq.homeoffice.gov.uk
     commands:
       - export KUBE_TOKEN=$$PROD_KUBE_TOKEN
       - export KUBE_SERVER=$$PROD_KUBE_SERVER


### PR DESCRIPTION
Updated production URL to enable cutover